### PR TITLE
Upgrade ray.is_close function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- Implemented `is_close` method for `Ray` type to facilitate robust geometric testing 
+and added comprehensive unit tests for floating-point edge cases ([PR #10](https://github.com/scaioo/RayTraceRS/pull/10)).
 - Introduced a unified camera system via `Camera` trait
 - Added `OrthogonalCamera` and `PerspectiveCamera` implementations
 - Added configurable aspect ratio support for cameras
@@ -12,10 +14,15 @@
 - Added camera-based ray generation via `fire_ray(u, v)`
 
 ### Changed
+- Refactored `geometry::are_close` to provide robust handling of non-finite values ([PR #10](https://github.com/scaioo/RayTraceRS/pull/10)).
+- Streamlined `is_close` implementations across the codebase to follow idiomatic Rust expression-based returns.
 - Ray generation is now fully camera-driven via `Camera::fire_ray`
 - Rendering flow moved from implicit ray construction to `ImageTracer`
 - Pixel sampling now uses normalized coordinates (u, v) based on image resolution
 - Transformation pipeline now consistently applies homogeneous matrix transforms to rays
+
+### Fixes
+- Resolved potential silent failures in ray-surface intersection tests caused by floating-point rounding errors.
 
 ### Notes
 - This release corresponds to the `camera` branch and introduces a major architectural refactor of the rendering system.

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -25,8 +25,10 @@ pub static IDENTITY_4X4: [f32; 16] = [
 /// assert!(!are_close(1.0, 2.0));
 /// ```
 pub fn are_close(x: f32, y: f32) -> bool {
-    let epsilon = 1e-5;
-    (x - y).abs() < epsilon
+    match (x.is_finite(), y.is_finite()) {
+        (true, true) => (x - y).abs() < 1e-5,
+        _ => x == y || (x.is_nan() && y.is_nan()),
+    }
 }
 
 /// Converts an endianness value into a numeric representation.
@@ -200,6 +202,7 @@ pub fn equal_matrices(mat1: &[f32; 16], mat2: &[f32; 16]) -> bool {
 // tests
 #[cfg(test)]
 mod tests {
+    use image::ExtendedColorType::A8;
     //use crate::geometry::{is_close, Vector};
     use super::*;
 
@@ -215,6 +218,19 @@ mod tests {
         if !are_close(x, y) {
             panic!("are_close is not working");
         }
+
+        let x = f32::NAN;
+        let y = f32::NAN;
+        assert!(are_close(x, y));
+
+        let x = f32::INFINITY;
+        assert!(!are_close(x, y));
+
+        let y = f32::NEG_INFINITY;
+        assert!(!are_close(x, y));
+
+        let y = f32::INFINITY;
+        assert!(are_close(x, y));
     }
 
     #[test]

--- a/src/image_tracer.rs
+++ b/src/image_tracer.rs
@@ -55,7 +55,7 @@ mod tests {
 
         let ray_1 = tracer.fire_ray(0, 0, 2.5, 1.5);
         let ray_2 = tracer.fire_ray(2, 1, 0.5, 0.5);
-        assert!(ray_1.is_close(ray_2)?);
+        assert!(ray_1.is_close(ray_2));
 
         tracer.fire_all_rays(|_ray| Ok(Color::new(1.0, 2.0, 3.0)))?;
 

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -9,10 +9,10 @@ use crate::geometry::{Point, Vector, is_close};
 use crate::transformations::{
     Scaling, Transformation, Translation, XRotation, YRotation, ZRotation,
 };
-use anyhow::{Result, anyhow};
 use std::f32;
 use std::fmt::{Display, Formatter};
 use std::ops::Mul;
+use crate::functions::are_close;
 
 //================================================================
 //                    Struct definition
@@ -71,23 +71,12 @@ impl Ray {
         self.t_min = t_min;
     }
 
-    pub fn is_close(self, other: Ray) -> Result<bool> {
-        let condition = is_close(self.origin, other.origin)
+    pub fn is_close(self, other: Ray) -> bool {
+        is_close(self.origin, other.origin)
             && is_close(self.dir, other.dir)
-            && self.t_max == other.t_max
-            && self.t_min == other.t_min
-            && self.depth == other.depth;
-
-        if !condition {
-            Err(anyhow!(
-                "Two rays are not approximately equal!\
-            \nFirst ray:\n{}\nSecond ray:\n{}\n",
-                self,
-                other
-            ))
-        } else {
-            Ok(true)
-        }
+            && are_close(self.t_max, other.t_max)
+            && are_close(self.t_min, other.t_min)
+            && self.depth == other.depth
     }
 
     pub fn at(&self, t: f32) -> Point {
@@ -165,8 +154,11 @@ mod tests {
             Point::new(1.0, 1.9999999, 3.0),
             Vector::new(4.000001, 5.0, 6.0),
         );
+        
+        
+        assert!(ray1.is_close(ray2));
         ray2.t_min = 0.0001;
-        ray1.is_close(ray2).unwrap();
+        assert!(!ray1.is_close(ray2));
     }
 
     #[test]

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -5,6 +5,7 @@
 //! - `dir : Vector` (direction of the light ray)
 //! - `t_min : f32` ... TODO DOCKING
 
+use crate::functions::are_close;
 use crate::geometry::{Point, Vector, is_close};
 use crate::transformations::{
     Scaling, Transformation, Translation, XRotation, YRotation, ZRotation,
@@ -12,7 +13,6 @@ use crate::transformations::{
 use std::f32;
 use std::fmt::{Display, Formatter};
 use std::ops::Mul;
-use crate::functions::are_close;
 
 //================================================================
 //                    Struct definition
@@ -154,8 +154,7 @@ mod tests {
             Point::new(1.0, 1.9999999, 3.0),
             Vector::new(4.000001, 5.0, 6.0),
         );
-        
-        
+
         assert!(ray1.is_close(ray2));
         ray2.t_min = 0.0001;
         assert!(!ray1.is_close(ray2));

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -161,10 +161,11 @@ mod tests {
     #[test]
     fn test_is_close() {
         let ray1 = Ray::new(Point::new(1.0, 2.0, 3.0), Vector::new(4.0, 5.0, 6.0));
-        let ray2 = Ray::new(
+        let mut ray2 = Ray::new(
             Point::new(1.0, 1.9999999, 3.0),
             Vector::new(4.000001, 5.0, 6.0),
         );
+        ray2.t_min = 0.0001;
         ray1.is_close(ray2).unwrap();
     }
 


### PR DESCRIPTION
The current `is_close` method for `Ray` type shows two concerns regarding precision and efficiency:
1. the use of floating-point comparison `==`
2. a redundant `Return` logic. 

This PR refactors the method to improve code robustness and performance.

Instead of adding a workaround in `ray.is_close`, I updated `geometry::are_close` to support this use case cleanly. This function is widely used, so I verified existing behavior remains unchanged.