### PR TITLE
Add EUPL license notice to files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rstrace"
 version = "0.1.0"
 edition = "2024"
+license = "EUPL-1.2"
 
 [dependencies]
 anyhow = "1.0.102"

--- a/src/brdf.rs
+++ b/src/brdf.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! # BRDF — Bidirectional Reflectance Distribution Functions
 //!
 //! This module defines the [`BRDF`] trait and its implementations:

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! The camera is responsible for firing light rays into the 3D scene.
 //! By default, before any transformation is applied, the camera looks down the
 //! **positive X-axis**.

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! Utility types and operations for colors used in the ray tracing crate.
 //!
 //! This module provides the basic architecture to treat a single pixel color.

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! Utility functions used across the raytracer.
 //!
 //! This module provides small, reusable helpers that are not tied to a

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! Geometry module providing the spatial primitives used by the renderer.
 use crate::functions::are_close;
 use std::fmt;

--- a/src/hdr_image.rs
+++ b/src/hdr_image.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! HDR Image Module
 //!
 //! This module defines the [`HDR`] struct, which represents a High Dynamic Range

--- a/src/hit_record.rs
+++ b/src/hit_record.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! Contains the [`HitRecord`] structure, which stores data about ray-surface intersections.
 //!
 //! In a raytracer, when a ray intersects an object, we need to know more than just a boolean

--- a/src/image_tracer.rs
+++ b/src/image_tracer.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! The `ImageTracer` module ties together the `Camera` and the `HDR` image.
 //!
 //! It acts as the main rendering engine. Its primary responsibilities are:

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! Lexer for the raytracer scene files.
 //!
 //! Defines the structures to read and tokenize a scene file,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,10 @@
 //! - [`hdr_image`] — HDR image buffer, tone mapping (Reinhard), gamma correction,
 //!   and PNG export.
 //! - [`pfm_func`] — PFM file format reading and byte-order handling.
+//! 
+//! ### License
+//! 
+//! This file is licensed under the EUPL-1.2. See LICENSE.md.
 
 pub mod brdf;
 pub mod camera;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,9 @@
 //! - [`hdr_image`] — HDR image buffer, tone mapping (Reinhard), gamma correction,
 //!   and PNG export.
 //! - [`pfm_func`] — PFM file format reading and byte-order handling.
-//! 
+//!
 //! ### License
-//! 
+//!
 //! This file is licensed under the EUPL-1.2. See LICENSE.md.
 
 pub mod brdf;

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! # Materials
 //!
 //! This module defines [`Material`], the surface descriptor attached to every

--- a/src/pcg.rs
+++ b/src/pcg.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! # PCG — Permuted Congruential Generator
 //!
 //! A fast, statistically high-quality pseudo-random number generator (PRNG)

--- a/src/pfm_func.rs
+++ b/src/pfm_func.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! PFM (Portable Float Map) image reading utilities.
 //!
 //! This module provides functions to parse and load `.pfm` outputs into the

--- a/src/pigments.rs
+++ b/src/pigments.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! Surface pigmentation system for the ray tracer.
 //!
 //! This module defines the [`Pigment`] trait and several implementations

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! Ray representation utilities.
 //!
 //! A [`Ray`] represents a parametrized half-line in 3D space:

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! # Renderers
 //!
 //! This module defines the [`Renderer`] trait and its three implementations,

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! # Shapes
 //!
 //! This module defines the geometric primitives that can be placed in a ray-tracer scene.

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! Affine transformations in 3D space using homogeneous coordinates.
 //!
 //! This module provides the mathematical foundation for positioning, rotating,

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,3 +1,5 @@
+// This file is licensed under the EUPL-1.2. See LICENSE.md.
+
 //! A scene is represented as a collection of geometric objects.
 //! This module implements a list of shapes: the `World` type.
 //!


### PR DESCRIPTION
This PR adds a short notice clarifying that this file is released under the EUPL license, pointing to the main `LICENSE.md` file for the full text.