### PR TITLE
Fix issue #25

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ## Head
 
+- Fix an issue with UV coordinate orientation
+  ([#25](https://github.com/scaioo/RayTraceRS/issues/25), [PR#27](https://github.com/scaioo/RayTraceRS/pull/27)).
 - Implement Antialiasing ([PR#22](https://github.com/scaioo/RayTraceRS/pull/22)).
 - Build lexer ([PR#18](https://github.com/scaioo/RayTraceRS/pull/18)).
 
@@ -42,8 +44,7 @@
   [EUPL](https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12).
 - Fix an issue with the vertical order of the images
   ([#7](https://github.com/scaioo/RayTraceRS/issues/7), [PR#8](https://github.com/scaioo/RayTraceRS/pull/8)).
-- Fix an issue with sphere-ray intersections
-- [#15](https://github.com/scaioo/RayTraceRS/issues/15), [PR#16](https://github.com/scaioo/RayTraceRS/pull/16).
+- Fix an issue with sphere-ray intersections [#15](https://github.com/scaioo/RayTraceRS/issues/15), [PR#16](https://github.com/scaioo/RayTraceRS/pull/16).
 
 ---
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -37,6 +37,11 @@ impl Vec2D {
         are_close(self.x, other.x) && are_close(self.y, other.y)
     }
 
+    /// Returns this vector rotated 90° clockwise: `(x, y) → (y, -x)`.
+    ///
+    /// Used to reconcile the coordinate convention mismatch between UV space
+    /// (Y-axis forward) and the renderer (X-axis forward), so that texture
+    /// lookups via `get_color` receive correctly oriented coordinates.
     pub fn orient(&self) -> Vec2D {
         Vec2D {
             x: self.y,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -36,6 +36,13 @@ impl Vec2D {
     pub fn is_close(&self, other: &Vec2D) -> bool {
         are_close(self.x, other.x) && are_close(self.y, other.y)
     }
+
+    pub fn orient(&self) -> Vec2D {
+        Vec2D {
+            x: self.y,
+            y: -self.x,
+        }
+    }
 }
 
 // =======================================================================

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -132,7 +132,7 @@ impl Renderer for FlatRenderer {
             Some(hit) => {
                 // The ray hit an object!
                 // We ask the material's pigment for the color at the specific (u, v) coordinates.
-                let color = hit.material.pigment.get_color(&hit.uv)?;
+                let color = hit.material.pigment.get_color(&(hit.uv).orient())?;
                 Ok(color)
             }
             None => {
@@ -207,8 +207,10 @@ impl Renderer for PathTracer {
         };
 
         let material = &hit_record.material;
-        let mut hit_color = material.pigment.get_color(&hit_record.uv)?;
-        let emitted_radiance = material.emitted_radiance.get_color(&hit_record.uv)?;
+        let mut hit_color = material.pigment.get_color(&(hit_record.uv.orient()))?;
+        let emitted_radiance = material
+            .emitted_radiance
+            .get_color(&(hit_record.uv.orient()))?;
 
         let hit_color_lum = hit_color.r.max(hit_color.g).max(hit_color.b);
 


### PR DESCRIPTION
This PR resolves the orientation mapping mismatch (issue #25 ). The issue was a coordinate logic discrepancy rather than a code bug:

- Original mapping: Expected Y-axis as up/forward and X-axis as horizontal.
- Renderer logic: Uses X-axis as up/forward and Y-axis as horizontal.

This has been resolved by adjusting the coordinate translation logic within the `PathTracer` implementation with a new `Vec2D` method. The solution has been tested visually. 