### PR TITLE
Fix issue #30

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -132,6 +132,17 @@ impl Color {
         self.b = self.b / (self.b + 1.0);
         Ok(())
     }
+
+    pub fn rescale(&mut self) -> Result<()> {
+        self.self_check()?;
+        let highest = self.r.max(self.g.max(self.b));
+        if highest > 1.0 {
+            self.r = self.r / highest;
+            self.g = self.g / highest;
+            self.b = self.b / highest;
+        }
+        Ok(())
+    }
 }
 
 // =================================================================
@@ -498,5 +509,21 @@ mod tests {
         assert_eq!(color.r, 1.0 / (1.0 + 1.0));
         assert_eq!(color.g, 2.5 / (2.5 + 1.0));
         assert_eq!(color.b, 5.0 / (5.0 + 1.0));
+    }
+
+    #[test]
+    fn test_rescale() {
+        let mut color = Color::new(1.0, 2.0, 4.0);
+        let expected = Color::new(0.25, 0.4, 1.0);
+        color.rescale().unwrap();
+        assert!(color.is_close(&expected), "color: {:?}\nexpected: {:?}", color, expected);
+    }
+
+    #[test]
+    fn test_rescale_null() {
+        let mut color = Color::new(0.25, 0.4, 1.0);
+        let expected = color;
+        color.rescale().unwrap();
+        assert!(color.is_close(&expected), "color: {:?}\nexpected: {:?}", color, expected);
     }
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -19,7 +19,6 @@
 
 use crate::brdf::{BRDF, DiffusiveBrdf};
 use crate::color::{BLACK, Color};
-use crate::functions::Within;
 use crate::geometry::Vec2D;
 use crate::pigments::{Pigment, UniformPigment};
 
@@ -33,25 +32,17 @@ pub struct ClampPigment {
 
 impl ClampPigment {
     pub fn new(pigment: Box<dyn Pigment>) -> Self {
-        ClampPigment { pigment }
-    }
-
-    fn clamping_condition(color: &Color) -> bool {
-        color.r.is_between_close(&0.0, &1.0)
-            && color.g.is_between_close(&0.0, &1.0)
-            && color.b.is_between_close(&0.0, &1.0)
+        Self {
+            pigment
+        }
     }
 }
 
 impl Pigment for ClampPigment {
     fn get_color(&self, uv: &Vec2D) -> anyhow::Result<Color> {
         let mut color = self.pigment.get_color(uv)?;
-        if ClampPigment::clamping_condition(&color) {
+            color.rescale()?;
             Ok(color)
-        } else {
-            color.tone_map()?;
-            Ok(color)
-        }
     }
 }
 
@@ -204,7 +195,7 @@ mod tests {
         let clamp_pigment = ClampPigment::new(Box::new(pigment));
 
         let color = clamp_pigment.get_color(&Vec2D::new(0.0, 0.0)).unwrap();
-        let expected = Color::new(10.0 / 11.0, 100.0 / 101.0, 0.5);
+        let expected = Color::new(10.0 / 100.0, 100.0 / 100.0, 1.0/100.0);
         assert!(
             color.is_close(&expected),
             "color: {:?}\n expected: {:?}",

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -18,8 +18,42 @@
 //! `Material` itself generic.
 
 use crate::brdf::{BRDF, DiffusiveBrdf};
-use crate::color::BLACK;
+use crate::color::{BLACK, Color};
+use crate::functions::Within;
+use crate::geometry::Vec2D;
 use crate::pigments::{Pigment, UniformPigment};
+
+// ======================================================================
+// ClampPigment struct
+// ======================================================================
+#[derive(Clone)]
+pub struct ClampPigment {
+    pub pigment: Box<dyn Pigment>,
+}
+
+impl ClampPigment {
+    pub fn new(pigment: Box<dyn Pigment>) -> Self {
+        ClampPigment { pigment }
+    }
+
+    fn clamping_condition(color: &Color) -> bool {
+        color.r.is_between_close(&0.0, &1.0)
+            && color.g.is_between_close(&0.0, &1.0)
+            && color.b.is_between_close(&0.0, &1.0)
+    }
+}
+
+impl Pigment for ClampPigment {
+    fn get_color(&self, uv: &Vec2D) -> anyhow::Result<Color> {
+        let mut color = self.pigment.get_color(uv)?;
+        if ClampPigment::clamping_condition(&color) {
+            Ok(color)
+        } else {
+            color.tone_map()?;
+            Ok(color)
+        }
+    }
+}
 
 // ======================================================================
 // Material struct
@@ -45,7 +79,7 @@ use crate::pigments::{Pigment, UniformPigment};
 
 #[derive(Clone)]
 pub struct Material {
-    /// Colour or texture of the surface, evaluated at UV coordinates.
+    /// Color or texture of the surface, evaluated at UV coordinates.
     pub pigment: Box<dyn Pigment>,
     /// Reflectance model: determines how incoming light scatters off the surface.
     pub brdf: Box<dyn BRDF>,
@@ -82,7 +116,7 @@ impl Material {
         emitted_radiance: impl Pigment + 'static,
     ) -> Self {
         Material {
-            pigment: Box::new(pigment),
+            pigment: Box::new(ClampPigment::new(Box::new(pigment))),
             brdf: Box::new(brdf),
             emitted_radiance: Box::new(emitted_radiance),
         }
@@ -110,5 +144,49 @@ impl Default for Material {
             brdf: Box::new(DiffusiveBrdf::default()),
             emitted_radiance: Box::new(UniformPigment::new(BLACK)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::color::WHITE;
+    use crate::pigments::CheckeredPigment;
+    use super::*;
+    
+    #[test]
+    fn test_material_clamped() {
+        let pigment = CheckeredPigment::new(Color::new(1.0,2.0,3.0), Color::new(4.0, 5.0, 6.0), 2);
+        let brdf = DiffusiveBrdf{};
+        let emitted_radiance = UniformPigment::new(Color::new(1000.0,2.0,1.0));
+        
+        let material = Material::new(pigment, brdf, emitted_radiance);
+        
+        let color = material.pigment.get_color(&Vec2D::new(0.25, 0.25)).unwrap();
+        let expected = Color::new(0.5, 2.0/ 3.0, 0.75);
+        assert!(color.is_close(&expected), "Pigment clamping assert failed:\ncolor: {:?}, expected: {:?}", color, expected);
+        
+        let color = material.emitted_radiance.get_color(&Vec2D::new(0.25, 0.25)).unwrap();
+        let expected = Color::new(1000.0,2.0,1.0);
+        assert!(color.is_close(&expected), "Emissive assert failed:\ncolor: {:?}, expected: {:?}", color, expected);
+
+    }
+    
+    #[test]
+    fn test_clamp_pigment_ok() {
+        let pigment = Box::new(UniformPigment::default());
+        let clamp_pigment = ClampPigment::new(pigment);
+
+        let color = clamp_pigment.get_color(&Vec2D::new(0.0, 0.0)).unwrap();
+        assert!(color.is_close(&WHITE), "color: {:?}\n expected: {:?}", color, WHITE );
+    }
+
+    #[test]
+    fn test_clamp_pigment_clamped() {
+        let pigment = UniformPigment::new(Color::new(10.0, 100.0, 1.0));
+        let clamp_pigment = ClampPigment::new(Box::new(pigment));
+
+        let color = clamp_pigment.get_color(&Vec2D::new(0.0, 0.0)).unwrap();
+        let expected = Color::new(10.0/11.0, 100.0/101.0, 0.5);
+        assert!(color.is_close(&expected),"color: {:?}\n expected: {:?}", color, expected);
     }
 }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -149,35 +149,53 @@ impl Default for Material {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::color::WHITE;
     use crate::pigments::CheckeredPigment;
-    use super::*;
-    
+
     #[test]
     fn test_material_clamped() {
-        let pigment = CheckeredPigment::new(Color::new(1.0,2.0,3.0), Color::new(4.0, 5.0, 6.0), 2);
-        let brdf = DiffusiveBrdf{};
-        let emitted_radiance = UniformPigment::new(Color::new(1000.0,2.0,1.0));
-        
-        let material = Material::new(pigment, brdf, emitted_radiance);
-        
-        let color = material.pigment.get_color(&Vec2D::new(0.25, 0.25)).unwrap();
-        let expected = Color::new(0.5, 2.0/ 3.0, 0.75);
-        assert!(color.is_close(&expected), "Pigment clamping assert failed:\ncolor: {:?}, expected: {:?}", color, expected);
-        
-        let color = material.emitted_radiance.get_color(&Vec2D::new(0.25, 0.25)).unwrap();
-        let expected = Color::new(1000.0,2.0,1.0);
-        assert!(color.is_close(&expected), "Emissive assert failed:\ncolor: {:?}, expected: {:?}", color, expected);
+        let pigment =
+            CheckeredPigment::new(Color::new(1.0, 2.0, 3.0), Color::new(4.0, 5.0, 6.0), 2);
+        let brdf = DiffusiveBrdf {};
+        let emitted_radiance = UniformPigment::new(Color::new(1000.0, 2.0, 1.0));
 
+        let material = Material::new(pigment, brdf, emitted_radiance);
+
+        let color = material.pigment.get_color(&Vec2D::new(0.25, 0.25)).unwrap();
+        let expected = Color::new(0.5, 2.0 / 3.0, 0.75);
+        assert!(
+            color.is_close(&expected),
+            "Pigment clamping assert failed:\ncolor: {:?}, expected: {:?}",
+            color,
+            expected
+        );
+
+        let color = material
+            .emitted_radiance
+            .get_color(&Vec2D::new(0.25, 0.25))
+            .unwrap();
+        let expected = Color::new(1000.0, 2.0, 1.0);
+        assert!(
+            color.is_close(&expected),
+            "Emissive assert failed:\ncolor: {:?}, expected: {:?}",
+            color,
+            expected
+        );
     }
-    
+
     #[test]
     fn test_clamp_pigment_ok() {
         let pigment = Box::new(UniformPigment::default());
         let clamp_pigment = ClampPigment::new(pigment);
 
         let color = clamp_pigment.get_color(&Vec2D::new(0.0, 0.0)).unwrap();
-        assert!(color.is_close(&WHITE), "color: {:?}\n expected: {:?}", color, WHITE );
+        assert!(
+            color.is_close(&WHITE),
+            "color: {:?}\n expected: {:?}",
+            color,
+            WHITE
+        );
     }
 
     #[test]
@@ -186,7 +204,12 @@ mod tests {
         let clamp_pigment = ClampPigment::new(Box::new(pigment));
 
         let color = clamp_pigment.get_color(&Vec2D::new(0.0, 0.0)).unwrap();
-        let expected = Color::new(10.0/11.0, 100.0/101.0, 0.5);
-        assert!(color.is_close(&expected),"color: {:?}\n expected: {:?}", color, expected);
+        let expected = Color::new(10.0 / 11.0, 100.0 / 101.0, 0.5);
+        assert!(
+            color.is_close(&expected),
+            "color: {:?}\n expected: {:?}",
+            color,
+            expected
+        );
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -435,9 +435,9 @@ mod tests {
         );
         // Verify that flat_renderer return the color of the sphere
         let expected_color = Color {
-            r: 1.0/(1.0 + 1.0),
+            r: 1.0 / (1.0 + 1.0),
             g: 2.0 / (2.0 + 1.0),
-            b: 3.0/(3.0 + 1.0),
+            b: 3.0 / (3.0 + 1.0),
         };
         assert!(
             tracer

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -434,12 +434,17 @@ mod tests {
             "Mismatch at (0,1)"
         );
         // Verify that flat_renderer return the color of the sphere
+        let expected_color = Color {
+            r: 1.0/(1.0 + 1.0),
+            g: 2.0 / (2.0 + 1.0),
+            b: 3.0/(3.0 + 1.0),
+        };
         assert!(
             tracer
                 .image
                 .get_pixel(1, 1)
                 .expect("Pixel (1,1) should exist")
-                .is_close(&sphere_color),
+                .is_close(&expected_color),
             "Mismatch at (1,1)"
         );
         assert!(

--- a/src/world.rs
+++ b/src/world.rs
@@ -35,6 +35,7 @@ impl World {
             // If the shape had an internal Result error (like in point_to_uv),
             // it already returned None via .ok()?, so the world stays safe.
             if let Some(hit) = object.ray_intersection(ray)
+                && hit.t >= ray.t_min
                 && hit.t < closest_t
             {
                 closest_t = hit.t;


### PR DESCRIPTION
This PR addresses issue #30 by separating two concepts:

- `pigment`, which represents the surface color/reflectance
- `emitted_radiance`, which represents self-emission


### The problem

When building `Material` no validation was run on `pigment`. This allowed unphysical color-reflectance values, which produced an unintended glittery effect.


### First approach (discarded)

The first solution explored was to rescale out-of-bound colors automatically. This fixed the invalid range, but it also introduced two drawbacks: 
+ It modified the input silently,
+ It could produce confusing results for the user when the original color distribution was not meant to be changed.


### Future workflow

The preferred fix is to move this responsibility to the scene parser. When the image-description text is parsed, the parser should know whether a texture is intended for `pigment` or for `emitted_radiance`, and it should build the corresponding `Material` field accordingly. To prevent unphysical artifacts while maintaining transparency, the parser must explicitly signal the user via a warning whenever an out-of-bounds input is automatically rescaled.


### TODO
- [ ] Merge the finished work from [PR#23](https://github.com/scaioo/RayTraceRS/pull/23);
- [ ] Add validation/rescaling in `parser.rs`.
- [ ] Add User warning.
- [ ] Update HISTORY.md

